### PR TITLE
updated get_token

### DIFF
--- a/moira.py
+++ b/moira.py
@@ -130,7 +130,7 @@ def get_token(username, password):
 	s = requests.Session()
 	s.get('http://www.marketwatch.com/')
 	s.post('https://secure.marketwatch.com/user/account/logon',
-		params=userdata)
+		data=userdata)
 	#TODO: Turn this into something that checks the cookiejar for .ASPXAUTH instead; this takes WAY too long.
 	if s.get('http://www.marketwatch.com/user/login/status').url == \
 		"http://www.marketwatch.com/my":


### PR DESCRIPTION
passing userdata as data rather than params forces requests to automatically append the content-length, which is required in some applications
